### PR TITLE
Fix: `no-std` dependencies

### DIFF
--- a/interpreter/src/call_create.rs
+++ b/interpreter/src/call_create.rs
@@ -1,5 +1,8 @@
 //! Call and create trap handler.
 
+#[cfg(not(feature = "std"))]
+use crate::Vec;
+
 use crate::utils::{h256_to_u256, u256_to_usize};
 use crate::{
 	Context, ExitError, ExitException, ExitResult, Machine, Memory, Opcode, RuntimeBackend,

--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use crate::Vec;
+
 use crate::{ExitError, Opcode};
 use alloc::rc::Rc;
 use primitive_types::{H160, H256, U256};

--- a/src/call_stack.rs
+++ b/src/call_stack.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::{Capture, ExitError, ExitFatal, ExitResult, Invoker, InvokerControl, InvokerMachine};
 use core::convert::Infallible;
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::{
 	Capture, Control, Etable, ExitResult, Gasometer, InvokerMachine, Machine, Opcode, RuntimeState,
 };

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -2,6 +2,9 @@ mod consts;
 mod costs;
 mod utils;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::standard::Config;
 use crate::{
 	ExitError, ExitException, ExitFatal, Gasometer as GasometerT, Machine, MergeStrategy, Opcode,

--- a/src/standard/invoker/mod.rs
+++ b/src/standard/invoker/mod.rs
@@ -1,6 +1,9 @@
 mod resolver;
 mod routines;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 pub use resolver::{EtableResolver, PrecompileSet, Resolver};
 
 use super::{Config, MergeableRuntimeState, TransactGasometer};

--- a/src/standard/invoker/resolver.rs
+++ b/src/standard/invoker/resolver.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use super::routines;
 use crate::standard::{Config, TransactGasometer};
 use crate::{

--- a/src/standard/invoker/routines.rs
+++ b/src/standard/invoker/routines.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use super::{CallTrapData, CreateTrapData, Resolver, SubstackInvoke, TransactGasometer};
 use crate::standard::Config;
 use crate::{


### PR DESCRIPTION
## Description

🦩 It solves issues for `no-std` build:
- [x] #243

To reproduce, just run ⬇️:
```
cargo build --no-default-features
```