### PR TITLE
Chore: Refactoring with simplification and more idiomatic clippy-way

### DIFF
--- a/interpreter/src/error.rs
+++ b/interpreter/src/error.rs
@@ -67,7 +67,7 @@ impl std::error::Error for ExitError {
 #[cfg(feature = "std")]
 impl std::fmt::Display for ExitError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{:?}", self)
+		write!(f, "{self:?}")
 	}
 }
 

--- a/interpreter/src/etable.rs
+++ b/interpreter/src/etable.rs
@@ -119,15 +119,18 @@ where
 }
 
 impl<S, H, Tr> Etable<S, H, Tr> {
+	#[must_use]
 	pub const fn none() -> Self {
 		Self([eval_unknown as _; 256], PhantomData)
 	}
 
+	#[must_use]
 	pub const fn pass() -> Self {
 		Self([eval_pass as _; 256], PhantomData)
 	}
 
 	/// Default core value for Etable.
+	#[must_use]
 	pub const fn core() -> Self {
 		let mut table = [eval_unknown as _; 256];
 
@@ -253,6 +256,7 @@ where
 	S: AsRef<RuntimeState> + GasState,
 {
 	/// Runtime Etable.
+	#[must_use]
 	pub const fn runtime() -> Self {
 		let mut table = Self::core();
 

--- a/interpreter/src/eval/misc.rs
+++ b/interpreter/src/eval/misc.rs
@@ -131,11 +131,11 @@ pub fn jumpi<S, Tr>(state: &mut Machine<S>) -> Control<Tr> {
 	pop_u256!(state, dest);
 	pop!(state, value);
 
-	if value != H256::zero() {
+	if value == H256::zero() {
+		Control::Continue
+	} else {
 		let dest = as_usize_or_fail!(dest, ExitException::InvalidJump);
 		Control::Jump(dest)
-	} else {
-		Control::Continue
 	}
 }
 

--- a/interpreter/src/eval/system.rs
+++ b/interpreter/src/eval/system.rs
@@ -179,11 +179,9 @@ pub fn returndatacopy<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> C
 	pop_u256!(machine, memory_offset, data_offset, len);
 
 	try_or_fail!(machine.memory.resize_offset(memory_offset, len));
-	if data_offset
-		.checked_add(len)
-		.map(|l| l > U256::from(machine.state.as_ref().retbuf.len()))
-		.unwrap_or(true)
-	{
+	if data_offset.checked_add(len).map_or(true, |l| {
+		l > U256::from(machine.state.as_ref().retbuf.len())
+	}) {
 		return Control::Exit(ExitException::OutOfOffset.into());
 	}
 

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -76,6 +76,7 @@ impl<S> Machine<S> {
 	}
 
 	/// Whether the machine has empty code.
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.code.is_empty()
 	}

--- a/interpreter/src/opcode.rs
+++ b/interpreter/src/opcode.rs
@@ -251,6 +251,7 @@ impl Opcode {
 
 impl Opcode {
 	/// Whether the opcode is a push opcode.
+	#[must_use]
 	pub fn is_push(&self) -> Option<u8> {
 		let value = self.0;
 		if (0x60..=0x7f).contains(&value) {
@@ -261,11 +262,13 @@ impl Opcode {
 	}
 
 	#[inline]
+	#[must_use]
 	pub const fn as_u8(&self) -> u8 {
 		self.0
 	}
 
 	#[inline]
+	#[must_use]
 	pub const fn as_usize(&self) -> usize {
 		self.0 as usize
 	}

--- a/interpreter/src/stack.rs
+++ b/interpreter/src/stack.rs
@@ -48,6 +48,7 @@ macro_rules! impl_perform_popn_pushn {
 
 impl Stack {
 	/// Create a new stack with given limit.
+	#[must_use]
 	pub const fn new(limit: usize) -> Self {
 		Self {
 			data: Vec::new(),
@@ -57,31 +58,35 @@ impl Stack {
 
 	#[inline]
 	/// Stack limit.
+	#[must_use]
 	pub const fn limit(&self) -> usize {
 		self.limit
 	}
 
 	#[inline]
 	/// Stack length.
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.data.len()
 	}
 
-	#[inline]
 	/// Whether the stack is empty.
+	#[inline]
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.data.is_empty()
 	}
 
 	#[inline]
 	/// Stack data.
+	#[must_use]
 	pub const fn data(&self) -> &Vec<H256> {
 		&self.data
 	}
 
 	/// Clear the stack.
 	pub fn clear(&mut self) {
-		self.data.clear()
+		self.data.clear();
 	}
 
 	#[inline]

--- a/interpreter/src/trap.rs
+++ b/interpreter/src/trap.rs
@@ -65,6 +65,7 @@ impl CreateScheme {
 		}
 	}
 
+	#[must_use]
 	pub const fn caller(&self) -> H160 {
 		match self {
 			Self::Create2 { caller, .. } => *caller,
@@ -118,6 +119,7 @@ pub enum CallCreateTrapData {
 }
 
 impl CallCreateTrapData {
+	#[must_use]
 	pub const fn target_gas(&self) -> Option<U256> {
 		match self {
 			Self::Call(CallTrapData { gas, .. }) => Some(*gas),
@@ -185,7 +187,7 @@ impl CallTrapData {
 		out_len: &H256,
 	) -> Result<((), Self), ExitError> {
 		let gas = h256_to_u256(*gas);
-		let value = value.map(|v| h256_to_u256(*v)).unwrap_or(U256::zero());
+		let value = value.map_or(U256::zero(), |v| h256_to_u256(*v));
 		let in_offset = h256_to_u256(*in_offset);
 		let in_len = h256_to_u256(*in_len);
 		let out_offset = h256_to_u256(*out_offset);
@@ -366,11 +368,11 @@ impl CallTrapData {
 		}
 	}
 
+	#[must_use]
 	pub fn has_value(&self) -> bool {
 		self.transfer
 			.as_ref()
-			.map(|t| t.value != U256::zero())
-			.unwrap_or(false)
+			.map_or(false, |t| t.value != U256::zero())
 	}
 }
 

--- a/interpreter/src/utils.rs
+++ b/interpreter/src/utils.rs
@@ -6,6 +6,7 @@ use core::ops::{Div, Rem};
 use primitive_types::{H256, U256};
 
 /// Convert [U256] into [H256].
+#[must_use]
 pub fn u256_to_h256(v: U256) -> H256 {
 	let mut r = H256::default();
 	v.to_big_endian(&mut r[..]);
@@ -13,6 +14,7 @@ pub fn u256_to_h256(v: U256) -> H256 {
 }
 
 /// Convert [H256] to [U256].
+#[must_use]
 pub fn h256_to_u256(v: H256) -> U256 {
 	U256::from_big_endian(&v[..])
 }
@@ -34,10 +36,10 @@ pub enum Sign {
 }
 
 const SIGN_BIT_MASK: U256 = U256([
-	0xffffffffffffffff,
-	0xffffffffffffffff,
-	0xffffffffffffffff,
-	0x7fffffffffffffff,
+	0xffff_ffff_ffff_ffff,
+	0xffff_ffff_ffff_ffff,
+	0xffff_ffff_ffff_ffff,
+	0x7fff_ffff_ffff_ffff,
 ]);
 
 /// Signed 256-bit integer.
@@ -46,10 +48,12 @@ pub struct I256(pub Sign, pub U256);
 
 impl I256 {
 	/// Zero value of I256.
+	#[must_use]
 	pub const fn zero() -> I256 {
 		I256(Sign::Zero, U256::zero())
 	}
 	/// Minimum value of I256.
+	#[must_use]
 	pub fn min_value() -> I256 {
 		I256(Sign::Minus, (U256::MAX & SIGN_BIT_MASK) + U256::from(1u64))
 	}

--- a/interpreter/src/valids.rs
+++ b/interpreter/src/valids.rs
@@ -7,6 +7,7 @@ pub struct Valids(Vec<bool>);
 
 impl Valids {
 	/// Create a new valid mapping from given code bytes.
+	#[must_use]
 	pub fn new(code: &[u8]) -> Self {
 		let mut valids: Vec<bool> = Vec::with_capacity(code.len());
 		valids.resize(code.len(), false);
@@ -30,18 +31,21 @@ impl Valids {
 	/// Get the length of the valid mapping. This is the same as the
 	/// code bytes.
 	#[inline]
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.0.len()
 	}
 
 	/// Returns true if the valids list is empty
 	#[inline]
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.len() == 0
 	}
 
 	/// Returns `true` if the position is a valid jump destination. If
 	/// not, returns `false`.
+	#[must_use]
 	pub fn is_valid(&self, position: usize) -> bool {
 		if position >= self.0.len() {
 			return false;

--- a/src/call_stack.rs
+++ b/src/call_stack.rs
@@ -249,8 +249,7 @@ where
 				match invoker.enter_substack(trap, &mut machine, backend, initial_depth + 1) {
 					Capture::Exit(Ok((trap_data, InvokerControl::Enter(sub_machine)))) => {
 						let (sub_result, sub_machine) = if heap_depth
-							.map(|hd| initial_depth + 1 >= hd)
-							.unwrap_or(false)
+							.map_or(false, |hd| initial_depth + 1 >= hd)
 						{
 							match CallStack::new(sub_machine, initial_depth + 1, backend, invoker)
 								.run()
@@ -381,10 +380,9 @@ where
 				invoker,
 				backend,
 			}) => {
-				let (transact_invoke, control) = match invoker.new_transact(args, backend) {
-					Ok((transact_invoke, control)) => (transact_invoke, control),
-					Err(err) => return Err(Capture::Exit(Err(err))),
-				};
+				let (transact_invoke, control) = invoker
+					.new_transact(args, backend)
+					.map_err(|err| Capture::Exit(Err(err)))?;
 
 				match control {
 					InvokerControl::Enter(machine) => {

--- a/src/standard/invoker/mod.rs
+++ b/src/standard/invoker/mod.rs
@@ -237,96 +237,99 @@ where
 			target: address,
 			value,
 		};
-
-		let work = || -> Result<(TransactInvoke, _), ExitError> {
-			match args {
-				TransactArgs::Call {
-					caller,
-					address,
-					data,
-					gas_limit,
-					access_list,
-					..
-				} => {
-					for (address, keys) in &access_list {
-						handler.mark_hot(*address, None);
-						for key in keys {
-							handler.mark_hot(*address, Some(*key));
-						}
-					}
-
-					let state = <R::State>::new_transact_call(
-						RuntimeState {
-							context,
-							transaction_context: Rc::new(transaction_context),
-							retbuf: Vec::new(),
-						},
-						gas_limit,
-						&data,
-						&access_list,
-						self.config,
-					)?;
-
-					let machine = routines::make_enter_call_machine(
-						self.config,
-						self.resolver,
-						address,
-						data,
-						Some(transfer),
-						state,
-						handler,
-					)?;
-
-					if self.config.increase_state_access_gas {
-						if self.config.warm_coinbase_address {
-							let coinbase = handler.block_coinbase();
-							handler.mark_hot(coinbase, None);
-						}
-						handler.mark_hot(caller, None);
-						handler.mark_hot(address, None);
-					}
-
-					Ok((invoke, machine))
-				}
-				TransactArgs::Create {
-					caller,
-					init_code,
-					gas_limit,
-					access_list,
-					..
-				} => {
-					let state = <R::State>::new_transact_create(
-						RuntimeState {
-							context,
-							transaction_context: Rc::new(transaction_context),
-							retbuf: Vec::new(),
-						},
-						gas_limit,
-						&init_code,
-						&access_list,
-						self.config,
-					)?;
-
-					let machine = routines::make_enter_create_machine(
-						self.config,
-						self.resolver,
-						caller,
-						init_code,
-						transfer,
-						state,
-						handler,
-					)?;
-
-					Ok((invoke, machine))
-				}
-			}
+		let runtime_state = RuntimeState {
+			context,
+			transaction_context: Rc::new(transaction_context),
+			retbuf: Vec::new(),
 		};
 
-		match work() {
-			Ok(ret) => Ok(ret),
-			Err(err) => {
-				handler.pop_substate(MergeStrategy::Discard);
-				Err(err)
+		match args {
+			TransactArgs::Call {
+				caller,
+				address,
+				data,
+				gas_limit,
+				access_list,
+				..
+			} => {
+				for (address, keys) in &access_list {
+					handler.mark_hot(*address, None);
+					for key in keys {
+						handler.mark_hot(*address, Some(*key));
+					}
+				}
+
+				let state = <R::State>::new_transact_call(
+					runtime_state,
+					gas_limit,
+					&data,
+					&access_list,
+					self.config,
+				)
+				.map_err(|err| {
+					handler.pop_substate(MergeStrategy::Discard);
+					err
+				})?;
+
+				let machine = routines::make_enter_call_machine(
+					self.config,
+					self.resolver,
+					address,
+					data,
+					Some(transfer),
+					state,
+					handler,
+				)
+				.map_err(|err| {
+					handler.pop_substate(MergeStrategy::Discard);
+					err
+				})?;
+
+				if self.config.increase_state_access_gas {
+					if self.config.warm_coinbase_address {
+						let coinbase = handler.block_coinbase();
+						handler.mark_hot(coinbase, None);
+					}
+					handler.mark_hot(caller, None);
+					handler.mark_hot(address, None);
+				}
+
+				Ok((invoke, machine))
+			}
+			TransactArgs::Create {
+				caller,
+				init_code,
+				gas_limit,
+				access_list,
+				..
+			} => {
+				let state = <R::State>::new_transact_create(
+					runtime_state,
+					gas_limit,
+					&init_code,
+					&access_list,
+					self.config,
+				)
+				.map_err(|err| {
+					handler.pop_substate(MergeStrategy::Discard);
+					err
+				})?;
+
+				let machine = routines::make_enter_create_machine(
+					self.config,
+					self.resolver,
+					caller,
+					init_code,
+					transfer,
+					state,
+					handler,
+				)
+				.map_err(|err| {
+					handler.pop_substate(MergeStrategy::Discard);
+					err
+				})?;
+
+				Ok((invoke, machine))
 			}
 		}
 	}


### PR DESCRIPTION
## Description

🔦  Refactored and simplified some parts of the code. And for some parts of the code applied more strict rules through clippy: `pedantic` and `nursery`. It's only partly compatible with that, as some part of the code, AFAIK represented for better readability. PR changes do not touch parts related to a better visual understanding of the code.

➡️  Additional notes about adding `map_err`: as it's more idiomatic way to process error flow for factored parts of code.