### PR TITLE
feat: support transient storage opcodes (EIP-1153)

### DIFF
--- a/interpreter/src/etable.rs
+++ b/interpreter/src/etable.rs
@@ -282,6 +282,8 @@ where
 		table.0[Opcode::SLOAD.as_usize()] = eval_sload as _;
 		table.0[Opcode::SSTORE.as_usize()] = eval_sstore as _;
 		table.0[Opcode::GAS.as_usize()] = eval_gas as _;
+		table.0[Opcode::TLOAD.as_usize()] = eval_tload as _;
+		table.0[Opcode::TSTORE.as_usize()] = eval_tstore as _;
 		table.0[Opcode::LOG0.as_usize()] = eval_log0 as _;
 		table.0[Opcode::LOG1.as_usize()] = eval_log1 as _;
 		table.0[Opcode::LOG2.as_usize()] = eval_log2 as _;

--- a/interpreter/src/eval/mod.rs
+++ b/interpreter/src/eval/mod.rs
@@ -1200,6 +1200,24 @@ pub fn eval_gas<S: GasState, H: RuntimeEnvironment + RuntimeBackend, Tr>(
 	self::system::gas(machine, handle)
 }
 
+pub fn eval_tload<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBackend, Tr>(
+	machine: &mut Machine<S>,
+	handle: &mut H,
+	_opcode: Opcode,
+	_position: usize,
+) -> Control<Tr> {
+	self::system::tload(machine, handle)
+}
+
+pub fn eval_tstore<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBackend, Tr>(
+	machine: &mut Machine<S>,
+	handle: &mut H,
+	_opcode: Opcode,
+	_position: usize,
+) -> Control<Tr> {
+	self::system::tstore(machine, handle)
+}
+
 pub fn eval_log0<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,

--- a/interpreter/src/eval/system.rs
+++ b/interpreter/src/eval/system.rs
@@ -47,6 +47,7 @@ pub fn balance<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBackend, T
 	handler: &mut H,
 ) -> Control<Tr> {
 	pop!(machine, address);
+	handler.mark_hot(address.into(), None);
 	push_u256!(machine, handler.balance(address.into()));
 
 	Control::Continue
@@ -126,6 +127,7 @@ pub fn extcodesize<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBacken
 	handler: &mut H,
 ) -> Control<Tr> {
 	pop!(machine, address);
+	handler.mark_hot(address.into(), None);
 	let code_size = handler.code_size(address.into());
 	push_u256!(machine, code_size);
 
@@ -137,6 +139,7 @@ pub fn extcodehash<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBacken
 	handler: &mut H,
 ) -> Control<Tr> {
 	pop!(machine, address);
+	handler.mark_hot(address.into(), None);
 	let code_hash = handler.code_hash(address.into());
 	push!(machine, code_hash);
 
@@ -149,6 +152,8 @@ pub fn extcodecopy<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBacken
 ) -> Control<Tr> {
 	pop!(machine, address);
 	pop_u256!(machine, memory_offset, code_offset, len);
+
+	handler.mark_hot(address.into(), None);
 	try_or_fail!(machine.memory.resize_offset(memory_offset, len));
 
 	let code = handler.code(address.into());
@@ -258,6 +263,7 @@ pub fn sload<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBackend, Tr>
 	handler: &mut H,
 ) -> Control<Tr> {
 	pop!(machine, index);
+	handler.mark_hot(machine.state.as_ref().context.address, Some(index));
 	let value = handler.storage(machine.state.as_ref().context.address, index);
 	push!(machine, value);
 
@@ -269,6 +275,7 @@ pub fn sstore<S: AsRef<RuntimeState>, H: RuntimeEnvironment + RuntimeBackend, Tr
 	handler: &mut H,
 ) -> Control<Tr> {
 	pop!(machine, index, value);
+	handler.mark_hot(machine.state.as_ref().context.address, Some(index));
 
 	match handler.set_storage(machine.state.as_ref().context.address, index, value) {
 		Ok(()) => Control::Continue,

--- a/interpreter/src/opcode.rs
+++ b/interpreter/src/opcode.rs
@@ -225,6 +225,10 @@ impl Opcode {
 	pub const SSTORE: Opcode = Opcode(0x55);
 	/// `GAS`
 	pub const GAS: Opcode = Opcode(0x5a);
+	/// `TLOAD`
+	pub const TLOAD: Opcode = Opcode(0x5c);
+	/// `TSTORE`
+	pub const TSTORE: Opcode = Opcode(0x5d);
 	/// `LOGn`
 	pub const LOG0: Opcode = Opcode(0xa0);
 	pub const LOG1: Opcode = Opcode(0xa1);

--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -113,6 +113,8 @@ pub trait RuntimeBaseBackend {
 	fn code(&self, address: H160) -> Vec<u8>;
 	/// Get storage value of address at index.
 	fn storage(&self, address: H160, index: H256) -> H256;
+	/// Get transient storage value of address at index.
+	fn transient_storage(&self, address: H160, index: H256) -> H256;
 
 	/// Check whether an address exists.
 	fn exists(&self, address: H160) -> bool;
@@ -138,6 +140,13 @@ pub trait RuntimeBackend: RuntimeBaseBackend {
 	fn mark_hot(&mut self, address: H160, index: Option<H256>);
 	/// Set storage value of address at index.
 	fn set_storage(&mut self, address: H160, index: H256, value: H256) -> Result<(), ExitError>;
+	/// Set transient storage value of address at index, transient storage gets discarded after every transaction. (see EIP-1153)
+	fn set_transient_storage(
+		&mut self,
+		address: H160,
+		index: H256,
+		value: H256,
+	) -> Result<(), ExitError>;
 	/// Create a log owned by address with given topics and data.
 	fn log(&mut self, log: Log) -> Result<(), ExitError>;
 	/// Mark an address to be deleted.

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -137,6 +137,14 @@ impl RuntimeBackend for UnimplementedHandler {
 	fn set_storage(&mut self, _address: H160, _index: H256, _value: H256) -> Result<(), ExitError> {
 		unimplemented!()
 	}
+	fn set_transient_storage(
+		&mut self,
+		_address: H160,
+		_index: H256,
+		_value: H256,
+	) -> Result<(), ExitError> {
+		unimplemented!()
+	}
 	fn log(&mut self, _log: Log) -> Result<(), ExitError> {
 		unimplemented!()
 	}

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -108,6 +108,9 @@ impl RuntimeBaseBackend for UnimplementedHandler {
 	fn storage(&self, _address: H160, _index: H256) -> H256 {
 		unimplemented!()
 	}
+	fn transient_storage(&self, _address: H160, _index: H256) -> H256 {
+		unimplemented!()
+	}
 
 	fn exists(&self, _address: H160) -> bool {
 		unimplemented!()

--- a/jsontests/src/in_memory.rs
+++ b/jsontests/src/in_memory.rs
@@ -21,6 +21,7 @@ pub struct InMemoryAccount {
 	pub code: Vec<u8>,
 	pub nonce: U256,
 	pub storage: BTreeMap<H256, H256>,
+	pub transient_storage: BTreeMap<H256, H256>,
 }
 
 #[derive(Clone, Debug)]
@@ -59,6 +60,16 @@ impl InMemoryBackend {
 				account.storage.remove(&key);
 			} else {
 				account.storage.insert(key, value);
+			}
+		}
+
+		for ((address, key), value) in changeset.transient_storage.clone() {
+			let account = self.state.entry(address).or_default();
+
+			if value == H256::default() {
+				account.transient_storage.remove(&key);
+			} else {
+				account.transient_storage.insert(key, value);
 			}
 		}
 
@@ -137,6 +148,17 @@ impl RuntimeBaseBackend for InMemoryBackend {
 			.cloned()
 			.unwrap_or(Default::default())
 			.storage
+			.get(&index)
+			.cloned()
+			.unwrap_or(H256::default())
+	}
+
+	fn transient_storage(&self, address: H160, index: H256) -> H256 {
+		self.state
+			.get(&address)
+			.cloned()
+			.unwrap_or(Default::default())
+			.transient_storage
 			.get(&index)
 			.cloned()
 			.unwrap_or(H256::default())

--- a/jsontests/src/run.rs
+++ b/jsontests/src/run.rs
@@ -138,6 +138,7 @@ pub fn run_test(
 					code: account.code.0,
 					nonce: account.nonce,
 					storage,
+					transient_storage: Default::default(),
 				},
 			)
 		})

--- a/src/standard/config.rs
+++ b/src/standard/config.rs
@@ -97,6 +97,8 @@ pub struct Config {
 	pub has_base_fee: bool,
 	/// Has PUSH0 opcode. See [EIP-3855](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3855.md)
 	pub has_push0: bool,
+	/// Enables transient storage. See [EIP-1153](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1153.md)
+	pub eip_1153_enabled: bool,
 }
 
 impl Config {
@@ -150,6 +152,7 @@ impl Config {
 			has_ext_code_hash: false,
 			has_base_fee: false,
 			has_push0: false,
+			eip_1153_enabled: false,
 		}
 	}
 
@@ -203,6 +206,7 @@ impl Config {
 			has_ext_code_hash: true,
 			has_base_fee: false,
 			has_push0: false,
+			eip_1153_enabled: false,
 		}
 	}
 
@@ -237,6 +241,7 @@ impl Config {
 			disallow_executable_format,
 			warm_coinbase_address,
 			max_initcode_size,
+			eip_1153_enabled,
 		} = inputs;
 
 		// See https://eips.ethereum.org/EIPS/eip-2929
@@ -299,6 +304,7 @@ impl Config {
 			has_ext_code_hash: true,
 			has_base_fee,
 			has_push0,
+			eip_1153_enabled,
 		}
 	}
 }
@@ -315,6 +321,7 @@ struct DerivedConfigInputs {
 	disallow_executable_format: bool,
 	warm_coinbase_address: bool,
 	max_initcode_size: Option<usize>,
+	eip_1153_enabled: bool,
 }
 
 impl DerivedConfigInputs {
@@ -329,6 +336,7 @@ impl DerivedConfigInputs {
 			disallow_executable_format: false,
 			warm_coinbase_address: false,
 			max_initcode_size: None,
+			eip_1153_enabled: false,
 		}
 	}
 
@@ -343,6 +351,7 @@ impl DerivedConfigInputs {
 			disallow_executable_format: true,
 			warm_coinbase_address: false,
 			max_initcode_size: None,
+			eip_1153_enabled: false,
 		}
 	}
 
@@ -357,6 +366,7 @@ impl DerivedConfigInputs {
 			disallow_executable_format: true,
 			warm_coinbase_address: false,
 			max_initcode_size: None,
+			eip_1153_enabled: false,
 		}
 	}
 
@@ -372,6 +382,7 @@ impl DerivedConfigInputs {
 			warm_coinbase_address: true,
 			// 2 * 24576 as per EIP-3860
 			max_initcode_size: Some(0xC000),
+			eip_1153_enabled: false,
 		}
 	}
 }

--- a/src/standard/gasometer/costs.rs
+++ b/src/standard/gasometer/costs.rs
@@ -242,11 +242,11 @@ pub fn sstore_cost(
 	)
 }
 pub fn tload_cost(config: &Config) -> Result<u64, ExitException> {
-	Ok(config.gas_sload)
+	Ok(config.gas_storage_read_warm)
 }
 
 pub fn tstore_cost(config: &Config) -> Result<u64, ExitException> {
-	Ok(config.gas_sload)
+	Ok(config.gas_storage_read_warm)
 }
 
 pub fn suicide_cost(value: U256, is_cold: bool, target_exists: bool, config: &Config) -> u64 {

--- a/src/standard/gasometer/costs.rs
+++ b/src/standard/gasometer/costs.rs
@@ -241,6 +241,13 @@ pub fn sstore_cost(
 		},
 	)
 }
+pub fn tload_cost(config: &Config) -> Result<u64, ExitException> {
+	Ok(config.gas_sload)
+}
+
+pub fn tstore_cost(config: &Config) -> Result<u64, ExitException> {
+	Ok(config.gas_sload)
+}
 
 pub fn suicide_cost(value: U256, is_cold: bool, target_exists: bool, config: &Config) -> u64 {
 	let eip161 = !config.empty_considered_exists;

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -278,7 +278,7 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 	stack: &Stack,
 	is_static: bool,
 	config: &Config,
-	handler: &H,
+	handler: &mut H,
 ) -> Result<(GasCost, Option<MemoryCost>), ExitError> {
 	let gas_cost = match opcode {
 		Opcode::RETURN => GasCost::Zero,
@@ -302,40 +302,59 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 
 		Opcode::EXTCODESIZE => {
 			let target = stack.peek(0)?.into();
-			GasCost::ExtCodeSize {
-				target_is_cold: handler.is_cold(target, None),
-			}
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
+			GasCost::ExtCodeSize { target_is_cold }
 		}
 		Opcode::BALANCE => {
 			let target = stack.peek(0)?.into();
-			GasCost::Balance {
-				target_is_cold: handler.is_cold(target, None),
-			}
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
+			GasCost::Balance { target_is_cold }
 		}
 		Opcode::BLOCKHASH => GasCost::BlockHash,
 
 		Opcode::EXTCODEHASH if config.has_ext_code_hash => {
 			let target = stack.peek(0)?.into();
-			GasCost::ExtCodeHash {
-				target_is_cold: handler.is_cold(target, None),
-			}
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
+			GasCost::ExtCodeHash { target_is_cold }
 		}
 		Opcode::EXTCODEHASH => GasCost::Invalid(opcode),
 
 		Opcode::CALLCODE => {
 			let target = stack.peek(1)?.into();
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
 			GasCost::CallCode {
 				value: U256::from_big_endian(&stack.peek(2)?[..]),
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
-				target_is_cold: handler.is_cold(target, None),
+				target_is_cold,
 				target_exists: { handler.exists(target) },
 			}
 		}
 		Opcode::STATICCALL => {
 			let target = stack.peek(1)?.into();
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
 			GasCost::StaticCall {
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
-				target_is_cold: handler.is_cold(target, None),
+				target_is_cold,
 				target_exists: { handler.exists(target) },
 			}
 		}
@@ -344,8 +363,13 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 		},
 		Opcode::EXTCODECOPY => {
 			let target = stack.peek(0)?.into();
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
 			GasCost::ExtCodeCopy {
-				target_is_cold: handler.is_cold(target, None),
+				target_is_cold,
 				len: U256::from_big_endian(&stack.peek(3)?[..]),
 			}
 		}
@@ -357,16 +381,25 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 		},
 		Opcode::SLOAD => {
 			let index = stack.peek(0)?;
-			GasCost::SLoad {
-				target_is_cold: handler.is_cold(address, Some(index)),
-			}
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(address, Some(index));
+			handler.mark_hot(address, Some(index));
+
+			GasCost::SLoad { target_is_cold }
 		}
+		Opcode::TLOAD => GasCost::TLoad,
 
 		Opcode::DELEGATECALL if config.has_delegate_call => {
 			let target = stack.peek(1)?.into();
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
 			GasCost::DelegateCall {
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
-				target_is_cold: handler.is_cold(target, None),
+				target_is_cold,
 				target_exists: { handler.exists(target) },
 			}
 		}
@@ -382,13 +415,18 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 			let index = stack.peek(0)?;
 			let value = stack.peek(1)?;
 
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(address, Some(index));
+			handler.mark_hot(address, Some(index));
+
 			GasCost::SStore {
 				original: handler.original_storage(address, index),
 				current: handler.storage(address, index),
 				new: value,
-				target_is_cold: handler.is_cold(address, Some(index)),
+				target_is_cold,
 			}
 		}
+		Opcode::TSTORE if !is_static => GasCost::TStore,
 		Opcode::LOG0 if !is_static => GasCost::Log {
 			n: 0,
 			len: U256::from_big_endian(&stack.peek(1)?[..]),
@@ -415,9 +453,14 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 		},
 		Opcode::SUICIDE if !is_static => {
 			let target = stack.peek(0)?.into();
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
 			GasCost::Suicide {
 				value: handler.balance(address),
-				target_is_cold: handler.is_cold(target, None),
+				target_is_cold,
 				target_exists: { handler.exists(target) },
 				already_removed: handler.deleted(address),
 			}
@@ -427,10 +470,15 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 				|| (is_static && U256::from_big_endian(&stack.peek(2)?[..]) == U256::zero()) =>
 		{
 			let target = stack.peek(1)?.into();
+
+			// https://eips.ethereum.org/EIPS/eip-2929
+			let target_is_cold = handler.is_cold(target, None);
+			handler.mark_hot(target, None);
+
 			GasCost::Call {
 				value: U256::from_big_endian(&stack.peek(2)?[..]),
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
-				target_is_cold: handler.is_cold(target, None),
+				target_is_cold,
 				target_exists: { handler.exists(target) },
 			}
 		}
@@ -600,6 +648,10 @@ enum GasCost {
 		/// True if target has not been previously accessed in this transaction
 		target_is_cold: bool,
 	},
+	/// Gas cost for `TLOAD`.
+	TLoad,
+	/// Gas cost for `TSTORE`.
+	TStore,
 	/// Gas cost for `SHA3`.
 	Sha3 {
 		/// Length of the data.
@@ -696,7 +748,8 @@ impl GasCost {
 				new,
 				target_is_cold,
 			} => costs::sstore_cost(original, current, new, gas, target_is_cold, config)?,
-
+			GasCost::TLoad => costs::tload_cost(config)?,
+			GasCost::TStore => costs::tstore_cost(config)?,
 			GasCost::Sha3 { len } => costs::sha3_cost(len)?,
 			GasCost::Log { n, len } => costs::log_cost(n, len)?,
 			GasCost::VeryLowCopy { len } => costs::verylowcopy_cost(len)?,

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -361,7 +361,7 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 				target_is_cold: handler.is_cold(address, Some(index)),
 			}
 		}
-		Opcode::TLOAD => GasCost::TLoad,
+		Opcode::TLOAD if config.eip_1153_enabled => GasCost::TLoad,
 
 		Opcode::DELEGATECALL if config.has_delegate_call => {
 			let target = stack.peek(1)?.into();
@@ -389,7 +389,7 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 				target_is_cold: handler.is_cold(address, Some(index)),
 			}
 		}
-		Opcode::TSTORE if !is_static => GasCost::TStore,
+		Opcode::TSTORE if !is_static && config.eip_1153_enabled => GasCost::TStore,
 		Opcode::LOG0 if !is_static => GasCost::Log {
 			n: 0,
 			len: U256::from_big_endian(&stack.peek(1)?[..]),

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -278,7 +278,7 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 	stack: &Stack,
 	is_static: bool,
 	config: &Config,
-	handler: &mut H,
+	handler: &H,
 ) -> Result<(GasCost, Option<MemoryCost>), ExitError> {
 	let gas_cost = match opcode {
 		Opcode::RETURN => GasCost::Zero,


### PR DESCRIPTION
This PR adds 2 new opcodes (`TLOAD` and `TSTORE`) for manipulating state that behaves almost identically to storage but is discarded after every transaction. 

These new instructions were introduced by [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) and included in Cancun fork.

Running the tests located at [`ethtests/GeneralStateTests/Cancun/stEIP1153-transientStorage`](https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller/Cancun/stEIP1153-transientStorage) will require the changes present in https://github.com/rust-ethereum/evm/pull/280