### PR TITLE
feat: support memory copying instruction (EIP-5656)

### DIFF
--- a/interpreter/src/etable.rs
+++ b/interpreter/src/etable.rs
@@ -174,6 +174,7 @@ impl<S, H, Tr> Etable<S, H, Tr> {
 		table[Opcode::PC.as_usize()] = eval_pc as _;
 		table[Opcode::MSIZE.as_usize()] = eval_msize as _;
 		table[Opcode::JUMPDEST.as_usize()] = eval_jumpdest as _;
+		table[Opcode::MCOPY.as_usize()] = eval_mcopy as _;
 
 		table[Opcode::PUSH0.as_usize()] = eval_push0 as _;
 		table[Opcode::PUSH1.as_usize()] = eval_push1 as _;

--- a/interpreter/src/eval/misc.rs
+++ b/interpreter/src/eval/misc.rs
@@ -1,7 +1,7 @@
 use super::Control;
 use crate::utils::u256_to_h256;
 use crate::{ExitError, ExitException, ExitFatal, ExitSucceed, Machine};
-use core::cmp::min;
+use core::cmp::{max,min};
 use primitive_types::{H256, U256};
 
 #[inline]
@@ -91,6 +91,19 @@ pub fn mload<S, Tr>(state: &mut Machine<S>) -> Control<Tr> {
 	let index = as_usize_or_fail!(index);
 	let value = H256::from_slice(&state.memory.get(index, 32)[..]);
 	push!(state, value);
+	Control::Continue
+}
+
+/// Support for EIP-5656: MCOPY instruction.
+#[inline]
+pub fn mcopy<S, Tr>(state: &mut Machine<S>) -> Control<Tr> {
+	pop_u256!(state, dst, src, len);
+	try_or_fail!(state.memory.resize_offset(max(dst,src), len));
+
+	let dst = as_usize_or_fail!(dst);
+	let src = as_usize_or_fail!(src);
+	let len = as_usize_or_fail!(len);
+	state.memory.copy(dst, src, len);
 	Control::Continue
 }
 

--- a/interpreter/src/eval/misc.rs
+++ b/interpreter/src/eval/misc.rs
@@ -1,7 +1,7 @@
 use super::Control;
 use crate::utils::u256_to_h256;
 use crate::{ExitError, ExitException, ExitFatal, ExitSucceed, Machine};
-use core::cmp::{max,min};
+use core::cmp::{max, min};
 use primitive_types::{H256, U256};
 
 #[inline]
@@ -98,7 +98,7 @@ pub fn mload<S, Tr>(state: &mut Machine<S>) -> Control<Tr> {
 #[inline]
 pub fn mcopy<S, Tr>(state: &mut Machine<S>) -> Control<Tr> {
 	pop_u256!(state, dst, src, len);
-	try_or_fail!(state.memory.resize_offset(max(dst,src), len));
+	try_or_fail!(state.memory.resize_offset(max(dst, src), len));
 
 	if len.is_zero() {
 		return Control::Continue;

--- a/interpreter/src/eval/misc.rs
+++ b/interpreter/src/eval/misc.rs
@@ -100,6 +100,10 @@ pub fn mcopy<S, Tr>(state: &mut Machine<S>) -> Control<Tr> {
 	pop_u256!(state, dst, src, len);
 	try_or_fail!(state.memory.resize_offset(max(dst,src), len));
 
+	if len.is_zero() {
+		return Control::Continue;
+	}
+
 	let dst = as_usize_or_fail!(dst);
 	let src = as_usize_or_fail!(src);
 	let len = as_usize_or_fail!(len);

--- a/interpreter/src/eval/mod.rs
+++ b/interpreter/src/eval/mod.rs
@@ -381,6 +381,15 @@ pub fn eval_jumpdest<S, H, Tr>(
 	Control::Continue
 }
 
+pub fn eval_mcopy<S, H, Tr>(
+	machine: &mut Machine<S>,
+	_handle: &mut H,
+	_opcode: Opcode,
+	_position: usize,
+) -> Control<Tr> {
+	self::misc::mcopy(machine)
+}
+
 pub fn eval_push0<S, H, Tr>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,

--- a/interpreter/src/machine/memory.rs
+++ b/interpreter/src/machine/memory.rs
@@ -314,7 +314,7 @@ mod tests {
 		memory.copy(3usize, 6usize, 2usize);
 
 		// Now the new memory data results in [0, 0, 0, 4, 0, 3, 4, 0].
-		// An extra element is added due to rezising.
+		// An extra element is added due to resizing.
 		assert_eq!(
 			memory.data(),
 			&[0u8, 0u8, 0u8, 4u8, 0u8, 3u8, 4u8, 0u8].to_vec()

--- a/interpreter/src/memory.rs
+++ b/interpreter/src/memory.rs
@@ -2,7 +2,7 @@ use crate::{ExitException, ExitFatal};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::{BitAnd, Not, Range};
-use core::{cmp::min, mem};
+use core::{cmp::{max, min}, mem};
 use primitive_types::U256;
 
 /// A sequencial memory. It uses Rust's `Vec` for internal
@@ -218,6 +218,15 @@ impl Memory {
 
 		self.set(memory_offset, data, Some(ulen))
 	}
+
+	/// Copies part of the memory inside another part of itself.
+	pub fn copy(&mut self, dst: usize, src: usize, len: usize ){
+		let resize_offset = max(dst,src);
+		if self.data.len() < resize_offset + len {
+			self.data.resize(resize_offset + len, 0);
+		}
+		self.data.copy_within(src..src + len, dst);
+	}
 }
 
 /// Rounds up `x` to the closest multiple of 32. If `x % 32 == 0` then `x` is returned.
@@ -229,7 +238,7 @@ fn next_multiple_of_32(x: U256) -> Option<U256> {
 
 #[cfg(test)]
 mod tests {
-	use super::{next_multiple_of_32, U256};
+	use super::{next_multiple_of_32, U256, Memory};
 
 	#[test]
 	fn test_next_multiple_of_32() {
@@ -261,5 +270,47 @@ mod tests {
 				assert_eq!(Some(last_multiple_of_32), next_multiple_of_32(x));
 			}
 		}
+	}
+
+	#[test]
+	fn test_memory_copy_works(){
+		// Create a new instance of memory
+		let mut memory = Memory::new(100usize);
+
+		// Set the [0,0,0,1,2,3,4] array as memory data.
+		//
+		// We insert the [1,2,3,4] array on index 3, 
+		// that's why we have the zero padding at the beginning.
+		memory.set(3usize, &[1u8,2u8,3u8,4u8], None).unwrap();
+		assert_eq!(memory.data(), &[0u8,0u8,0u8,1u8,2u8,3u8,4u8].to_vec());
+
+		// Copy 1 byte into index 0.
+		// As the length is 1, we only copy the byte present on index 3.
+		memory.copy(0usize, 3usize, 1usize);
+
+		// Now the new memory data results in [1,0,0,1,2,3,4]
+		assert_eq!(memory.data(), &[1u8,0u8,0u8,1u8,2u8,3u8,4u8].to_vec());
+	}
+
+	#[test]
+	fn test_memory_copy_resize(){
+		// Create a new instance of memory
+		let mut memory = Memory::new(100usize);
+
+		// Set the [0,0,0,1,2,3,4] array as memory data.
+		//
+		// We insert the [1,2,3,4] array on index 3, 
+		// that's why we have the zero padding at the beginning.
+		memory.set(3usize, &[1u8,2u8,3u8,4u8], None).unwrap();
+		assert_eq!(memory.data(), &[0u8,0u8,0u8,1u8,2u8,3u8,4u8].to_vec());
+
+		// Copy 2 bytes into index 3.
+		// As the length is 2, we copy the bytes present on indexes 6 and 7, 
+		// which are [4,0].
+		memory.copy(3usize, 6usize, 2usize);
+
+		// Now the new memory data results in [0, 0, 0, 4, 0, 3, 4, 0].
+		// An extra element is added due to rezising.
+		assert_eq!(memory.data(), &[0u8,0u8,0u8,4u8,0u8,3u8,4u8,0u8].to_vec());
 	}
 }

--- a/interpreter/src/memory.rs
+++ b/interpreter/src/memory.rs
@@ -2,7 +2,10 @@ use crate::{ExitException, ExitFatal};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::{BitAnd, Not, Range};
-use core::{cmp::{max, min}, mem};
+use core::{
+	cmp::{max, min},
+	mem,
+};
 use primitive_types::U256;
 
 /// A sequencial memory. It uses Rust's `Vec` for internal
@@ -220,8 +223,8 @@ impl Memory {
 	}
 
 	/// Copies part of the memory inside another part of itself.
-	pub fn copy(&mut self, dst: usize, src: usize, len: usize ){
-		let resize_offset = max(dst,src);
+	pub fn copy(&mut self, dst: usize, src: usize, len: usize) {
+		let resize_offset = max(dst, src);
 		if self.data.len() < resize_offset + len {
 			self.data.resize(resize_offset + len, 0);
 		}
@@ -238,7 +241,7 @@ fn next_multiple_of_32(x: U256) -> Option<U256> {
 
 #[cfg(test)]
 mod tests {
-	use super::{next_multiple_of_32, U256, Memory};
+	use super::{next_multiple_of_32, Memory, U256};
 
 	#[test]
 	fn test_next_multiple_of_32() {
@@ -273,44 +276,47 @@ mod tests {
 	}
 
 	#[test]
-	fn test_memory_copy_works(){
+	fn test_memory_copy_works() {
 		// Create a new instance of memory
 		let mut memory = Memory::new(100usize);
 
 		// Set the [0,0,0,1,2,3,4] array as memory data.
 		//
-		// We insert the [1,2,3,4] array on index 3, 
+		// We insert the [1,2,3,4] array on index 3,
 		// that's why we have the zero padding at the beginning.
-		memory.set(3usize, &[1u8,2u8,3u8,4u8], None).unwrap();
-		assert_eq!(memory.data(), &[0u8,0u8,0u8,1u8,2u8,3u8,4u8].to_vec());
+		memory.set(3usize, &[1u8, 2u8, 3u8, 4u8], None).unwrap();
+		assert_eq!(memory.data(), &[0u8, 0u8, 0u8, 1u8, 2u8, 3u8, 4u8].to_vec());
 
 		// Copy 1 byte into index 0.
 		// As the length is 1, we only copy the byte present on index 3.
 		memory.copy(0usize, 3usize, 1usize);
 
 		// Now the new memory data results in [1,0,0,1,2,3,4]
-		assert_eq!(memory.data(), &[1u8,0u8,0u8,1u8,2u8,3u8,4u8].to_vec());
+		assert_eq!(memory.data(), &[1u8, 0u8, 0u8, 1u8, 2u8, 3u8, 4u8].to_vec());
 	}
 
 	#[test]
-	fn test_memory_copy_resize(){
+	fn test_memory_copy_resize() {
 		// Create a new instance of memory
 		let mut memory = Memory::new(100usize);
 
 		// Set the [0,0,0,1,2,3,4] array as memory data.
 		//
-		// We insert the [1,2,3,4] array on index 3, 
+		// We insert the [1,2,3,4] array on index 3,
 		// that's why we have the zero padding at the beginning.
-		memory.set(3usize, &[1u8,2u8,3u8,4u8], None).unwrap();
-		assert_eq!(memory.data(), &[0u8,0u8,0u8,1u8,2u8,3u8,4u8].to_vec());
+		memory.set(3usize, &[1u8, 2u8, 3u8, 4u8], None).unwrap();
+		assert_eq!(memory.data(), &[0u8, 0u8, 0u8, 1u8, 2u8, 3u8, 4u8].to_vec());
 
 		// Copy 2 bytes into index 3.
-		// As the length is 2, we copy the bytes present on indexes 6 and 7, 
+		// As the length is 2, we copy the bytes present on indexes 6 and 7,
 		// which are [4,0].
 		memory.copy(3usize, 6usize, 2usize);
 
 		// Now the new memory data results in [0, 0, 0, 4, 0, 3, 4, 0].
 		// An extra element is added due to rezising.
-		assert_eq!(memory.data(), &[0u8,0u8,0u8,4u8,0u8,3u8,4u8,0u8].to_vec());
+		assert_eq!(
+			memory.data(),
+			&[0u8, 0u8, 0u8, 4u8, 0u8, 3u8, 4u8, 0u8].to_vec()
+		);
 	}
 }

--- a/interpreter/src/opcode.rs
+++ b/interpreter/src/opcode.rs
@@ -93,6 +93,8 @@ impl Opcode {
 	pub const MSIZE: Opcode = Opcode(0x59);
 	/// `JUMPDEST`
 	pub const JUMPDEST: Opcode = Opcode(0x5b);
+	/// `MCOPY`
+	pub const MCOPY: Opcode = Opcode(0x5e);
 
 	/// `PUSHn`
 	pub const PUSH0: Opcode = Opcode(0x5f);

--- a/src/standard/config.rs
+++ b/src/standard/config.rs
@@ -97,6 +97,8 @@ pub struct Config {
 	pub has_base_fee: bool,
 	/// Has PUSH0 opcode. See [EIP-3855](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3855.md)
 	pub has_push0: bool,
+	/// Enables MCOPY instruction. See [EIP-5656](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-5656.md)
+	pub eip_5656_enabled: bool,
 }
 
 impl Config {
@@ -150,6 +152,7 @@ impl Config {
 			has_ext_code_hash: false,
 			has_base_fee: false,
 			has_push0: false,
+			eip_5656_enabled: false,
 		}
 	}
 
@@ -203,6 +206,7 @@ impl Config {
 			has_ext_code_hash: true,
 			has_base_fee: false,
 			has_push0: false,
+			eip_5656_enabled: false,
 		}
 	}
 
@@ -237,6 +241,7 @@ impl Config {
 			disallow_executable_format,
 			warm_coinbase_address,
 			max_initcode_size,
+			eip_5656_enabled,
 		} = inputs;
 
 		// See https://eips.ethereum.org/EIPS/eip-2929
@@ -299,6 +304,7 @@ impl Config {
 			has_ext_code_hash: true,
 			has_base_fee,
 			has_push0,
+			eip_5656_enabled,
 		}
 	}
 }
@@ -315,6 +321,7 @@ struct DerivedConfigInputs {
 	disallow_executable_format: bool,
 	warm_coinbase_address: bool,
 	max_initcode_size: Option<usize>,
+	eip_5656_enabled: bool,
 }
 
 impl DerivedConfigInputs {
@@ -329,6 +336,7 @@ impl DerivedConfigInputs {
 			disallow_executable_format: false,
 			warm_coinbase_address: false,
 			max_initcode_size: None,
+			eip_5656_enabled: false,
 		}
 	}
 
@@ -343,6 +351,7 @@ impl DerivedConfigInputs {
 			disallow_executable_format: true,
 			warm_coinbase_address: false,
 			max_initcode_size: None,
+			eip_5656_enabled: false,
 		}
 	}
 
@@ -357,6 +366,7 @@ impl DerivedConfigInputs {
 			disallow_executable_format: true,
 			warm_coinbase_address: false,
 			max_initcode_size: None,
+			eip_5656_enabled: false,
 		}
 	}
 
@@ -372,6 +382,7 @@ impl DerivedConfigInputs {
 			warm_coinbase_address: true,
 			// 2 * 24576 as per EIP-3860
 			max_initcode_size: Some(0xC000),
+			eip_5656_enabled: false,
 		}
 	}
 }

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -349,7 +349,10 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 				len: U256::from_big_endian(&stack.peek(3)?[..]),
 			}
 		}
-		Opcode::CALLDATACOPY | Opcode::CODECOPY | Opcode::MCOPY => GasCost::VeryLowCopy {
+		Opcode::MCOPY if config.eip_5656_enabled => GasCost::VeryLowCopy {
+			len: U256::from_big_endian(&stack.peek(2)?[..]),
+		},
+		Opcode::CALLDATACOPY | Opcode::CODECOPY => GasCost::VeryLowCopy {
 			len: U256::from_big_endian(&stack.peek(2)?[..]),
 		},
 		Opcode::EXP => GasCost::Exp {

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -453,7 +453,14 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 			len: U256::from_big_endian(&stack.peek(1)?[..]),
 		}),
 
-		Opcode::CODECOPY | Opcode::CALLDATACOPY | Opcode::RETURNDATACOPY | Opcode::MCOPY => Some(MemoryCost {
+		Opcode::MCOPY => {
+			let top0 = U256::from_big_endian(&stack.peek(0)?[..]);
+			let top1 = U256::from_big_endian(&stack.peek(1)?[..]);
+			let offset = top0.max(top1);
+			Some(MemoryCost { offset, len: U256::from_big_endian(&stack.peek(2)?[..]) })
+		},
+
+		Opcode::CODECOPY | Opcode::CALLDATACOPY | Opcode::RETURNDATACOPY => Some(MemoryCost {
 			offset: U256::from_big_endian(&stack.peek(0)?[..]),
 			len: U256::from_big_endian(&stack.peek(2)?[..]),
 		}),

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -457,8 +457,11 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 			let top0 = U256::from_big_endian(&stack.peek(0)?[..]);
 			let top1 = U256::from_big_endian(&stack.peek(1)?[..]);
 			let offset = top0.max(top1);
-			Some(MemoryCost { offset, len: U256::from_big_endian(&stack.peek(2)?[..]) })
-		},
+			Some(MemoryCost {
+				offset,
+				len: U256::from_big_endian(&stack.peek(2)?[..]),
+			})
+		}
 
 		Opcode::CODECOPY | Opcode::CALLDATACOPY | Opcode::RETURNDATACOPY => Some(MemoryCost {
 			offset: U256::from_big_endian(&stack.peek(0)?[..]),

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -453,7 +453,7 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 			len: U256::from_big_endian(&stack.peek(1)?[..]),
 		}),
 
-		Opcode::CODECOPY | Opcode::CALLDATACOPY | Opcode::RETURNDATACOPY => Some(MemoryCost {
+		Opcode::CODECOPY | Opcode::CALLDATACOPY | Opcode::RETURNDATACOPY | Opcode::MCOPY => Some(MemoryCost {
 			offset: U256::from_big_endian(&stack.peek(0)?[..]),
 			len: U256::from_big_endian(&stack.peek(2)?[..]),
 		}),

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -349,7 +349,7 @@ fn dynamic_opcode_cost<H: RuntimeBackend>(
 				len: U256::from_big_endian(&stack.peek(3)?[..]),
 			}
 		}
-		Opcode::CALLDATACOPY | Opcode::CODECOPY => GasCost::VeryLowCopy {
+		Opcode::CALLDATACOPY | Opcode::CODECOPY | Opcode::MCOPY => GasCost::VeryLowCopy {
 			len: U256::from_big_endian(&stack.peek(2)?[..]),
 		},
 		Opcode::EXP => GasCost::Exp {


### PR DESCRIPTION
This PR adds an adaptation to [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) which introduces the `MCOPY` opcode. 

By using this new instruction, it is possible to copy parts of the memory in a cheaper and easier way, everything done with one opcode.

### Note

All the Cancun [ethereum-tests](https://github.com/ethereum/tests/tree/428f218d7d6f4a52544e12684afbfe6e2882ffbf/GeneralStateTests/Cancun/stEIP5656-MCOPY) related to `MCOPY` pass with this implementation.