### PR TITLE
feat: burn base fee when eip-1559 is enabled (>= london fork)

### DIFF
--- a/jsontests/src/run.rs
+++ b/jsontests/src/run.rs
@@ -121,8 +121,8 @@ pub fn run_test(
 		block_difficulty: test.env.current_difficulty,
 		block_randomness: Some(test.env.current_random),
 		block_gas_limit: test.env.current_gas_limit,
-		block_base_fee_per_gas: U256::zero(), // TODO: fill in this field.
-		chain_id: U256::zero(),               // TODO: fill in this field.
+		block_base_fee_per_gas: test.transaction.gas_price,
+		chain_id: U256::zero(), // TODO: fill in this field.
 	};
 
 	let state = test

--- a/jsontests/src/types.rs
+++ b/jsontests/src/types.rs
@@ -94,7 +94,11 @@ impl TestMulti {
 					transaction: TestTransaction {
 						data: self.transaction.data[post_state.indexes.data].0.clone(),
 						gas_limit: self.transaction.gas_limit[post_state.indexes.gas],
-						gas_price: self.transaction.gas_price.unwrap_or(U256::zero()),
+						gas_price: self
+							.transaction
+							.gas_price
+							.unwrap_or(self.env.current_base_fee),
+						gas_priority_fee: self.transaction.max_priority_fee_per_gas,
 						nonce: self.transaction.nonce,
 						secret_key: self.transaction.secret_key,
 						sender: self.transaction.sender,
@@ -236,6 +240,7 @@ pub struct TestTransaction {
 	pub data: Vec<u8>,
 	pub gas_limit: U256,
 	pub gas_price: U256,
+	pub gas_priority_fee: Option<U256>,
 	pub nonce: U256,
 	pub secret_key: H256,
 	pub sender: H160,

--- a/src/standard/config.rs
+++ b/src/standard/config.rs
@@ -101,6 +101,8 @@ pub struct Config {
 	pub eip_1153_enabled: bool,
 	/// Enables MCOPY instruction. See [EIP-5656](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-5656.md)
 	pub eip_5656_enabled: bool,
+	/// Uses EIP-1559 (Base fee is burned when this flag is enabled) [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
+	pub eip_1559_enabled: bool,
 }
 
 impl Config {
@@ -156,6 +158,7 @@ impl Config {
 			has_push0: false,
 			eip_1153_enabled: false,
 			eip_5656_enabled: false,
+			eip_1559_enabled: false,
 		}
 	}
 
@@ -211,6 +214,7 @@ impl Config {
 			has_push0: false,
 			eip_1153_enabled: false,
 			eip_5656_enabled: false,
+			eip_1559_enabled: false,
 		}
 	}
 
@@ -247,6 +251,7 @@ impl Config {
 			max_initcode_size,
 			eip_1153_enabled,
 			eip_5656_enabled,
+			eip_1559_enabled,
 		} = inputs;
 
 		// See https://eips.ethereum.org/EIPS/eip-2929
@@ -311,6 +316,7 @@ impl Config {
 			has_push0,
 			eip_1153_enabled,
 			eip_5656_enabled,
+			eip_1559_enabled,
 		}
 	}
 }
@@ -329,6 +335,7 @@ struct DerivedConfigInputs {
 	max_initcode_size: Option<usize>,
 	eip_1153_enabled: bool,
 	eip_5656_enabled: bool,
+	eip_1559_enabled: bool,
 }
 
 impl DerivedConfigInputs {
@@ -345,6 +352,7 @@ impl DerivedConfigInputs {
 			max_initcode_size: None,
 			eip_1153_enabled: false,
 			eip_5656_enabled: false,
+			eip_1559_enabled: false,
 		}
 	}
 
@@ -361,6 +369,7 @@ impl DerivedConfigInputs {
 			max_initcode_size: None,
 			eip_1153_enabled: false,
 			eip_5656_enabled: false,
+			eip_1559_enabled: true,
 		}
 	}
 
@@ -377,6 +386,7 @@ impl DerivedConfigInputs {
 			max_initcode_size: None,
 			eip_1153_enabled: false,
 			eip_5656_enabled: false,
+			eip_1559_enabled: true,
 		}
 	}
 
@@ -394,6 +404,7 @@ impl DerivedConfigInputs {
 			max_initcode_size: Some(0xC000),
 			eip_1153_enabled: false,
 			eip_5656_enabled: false,
+			eip_1559_enabled: true,
 		}
 	}
 }

--- a/src/standard/invoker/mod.rs
+++ b/src/standard/invoker/mod.rs
@@ -76,7 +76,7 @@ pub enum TransactValue {
 /// The invoke used in a top-layer transaction stack.
 pub struct TransactInvoke {
 	pub create_address: Option<H160>,
-	pub gas_fee: U256,
+	pub gas_limit: U256,
 	pub gas_price: U256,
 	pub caller: H160,
 }
@@ -241,7 +241,7 @@ where
 		let value = args.value();
 
 		let invoke = TransactInvoke {
-			gas_fee,
+			gas_limit: args.gas_limit(),
 			gas_price: args.gas_price(),
 			caller: args.caller(),
 			create_address: match &args {
@@ -398,8 +398,6 @@ where
 			Ok(_) | Err(ExitError::Reverted) => left_gas,
 			Err(_) => U256::zero(),
 		};
-		let refunded_fee = refunded_gas.saturating_mul(invoke.gas_price);
-		let coinbase_reward = invoke.gas_fee.saturating_sub(refunded_fee);
 
 		match &result {
 			Ok(_) => {
@@ -410,7 +408,22 @@ where
 			}
 		}
 
+		let refunded_fee = refunded_gas.saturating_mul(invoke.gas_price);
 		handler.deposit(invoke.caller, refunded_fee);
+		// Reward coinbase address
+		// EIP-1559 updated the fee system so that miners only get to keep the priority fee.
+		// The base fee is always burned.
+		let coinbase_gas_price = if substate.config().eip_1559_enabled {
+			invoke
+				.gas_price
+				.saturating_sub(handler.block_base_fee_per_gas())
+		} else {
+			invoke.gas_price
+		};
+		let coinbase_reward = invoke
+			.gas_limit
+			.saturating_mul(coinbase_gas_price)
+			.saturating_sub(refunded_fee);
 		handler.deposit(handler.block_coinbase(), coinbase_reward);
 
 		result


### PR DESCRIPTION
Also adds a new configuration property `eip_1159_enabled` which when set to true, burns the base fee, instead of sending it to the coinbase address.

> An important aspect of this fee system is that miners only get to keep the priority fee. The base fee is always burned (i.e. it is destroyed by the protocol). This ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform and reducing risks associated with miner extractable value (MEV). Additionally, this burn counterbalances Ethereum inflation while still giving the block reward and priority fee to miners. Finally, ensuring the miner of a block does not receive the base fee is important because it removes miner incentive to manipulate the fee in order to extract more fees from users.