### PR TITLE
Allow specifying the caller in `set_code` function

### DIFF
--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -156,7 +156,7 @@ pub trait RuntimeBackend: RuntimeBaseBackend {
 	/// Fully delete storages of an account.
 	fn reset_storage(&mut self, address: H160);
 	/// Set code of an account.
-	fn set_code(&mut self, address: H160, code: Vec<u8>) -> Result<(), ExitError>;
+	fn set_code(&mut self, address: H160, code: Vec<u8>, caller: Option<H160>) -> Result<(), ExitError>;
 	/// Reset balance of an account.
 	fn reset_balance(&mut self, address: H160);
 	fn deposit(&mut self, target: H160, value: U256);

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -165,7 +165,7 @@ impl RuntimeBackend for UnimplementedHandler {
 		unimplemented!()
 	}
 
-	fn set_code(&mut self, _address: H160, _code: Vec<u8>) -> Result<(), ExitError> {
+	fn set_code(&mut self, _address: H160, _code: Vec<u8>, _caller: Option<H160>) -> Result<(), ExitError> {
 		unimplemented!()
 	}
 

--- a/src/backend/overlayed.rs
+++ b/src/backend/overlayed.rs
@@ -192,7 +192,7 @@ impl<B: RuntimeBaseBackend> RuntimeBackend for OverlayedBackend<B> {
 		self.substate.storage_resets.insert(address);
 	}
 
-	fn set_code(&mut self, address: H160, code: Vec<u8>) -> Result<(), ExitError> {
+	fn set_code(&mut self, address: H160, code: Vec<u8>, _caller: Option<H160>) -> Result<(), ExitError> {
 		self.substate.codes.insert(address, code);
 		Ok(())
 	}

--- a/src/standard/invoker/mod.rs
+++ b/src/standard/invoker/mod.rs
@@ -375,6 +375,7 @@ where
 							retbuf,
 							&mut substate,
 							handler,
+							None
 						)?;
 
 						Ok(TransactValue::Create {
@@ -564,6 +565,7 @@ where
 		match trap_data {
 			SubstackInvoke::Create { address, trap } => {
 				let retbuf = retval;
+				let caller = trap.scheme.caller();
 
 				let result = result.and_then(|_| {
 					routines::deploy_create_code(
@@ -572,6 +574,7 @@ where
 						retbuf.clone(),
 						&mut substate,
 						handler,
+						Some(caller),
 					)?;
 
 					Ok(address)

--- a/src/standard/invoker/routines.rs
+++ b/src/standard/invoker/routines.rs
@@ -197,6 +197,7 @@ pub fn deploy_create_code<'config, S, H>(
 	retbuf: Vec<u8>,
 	state: &mut S,
 	handler: &mut H,
+	caller: Option<H160>,
 ) -> Result<(), ExitError>
 where
 	S: InvokerState<'config>,
@@ -212,7 +213,7 @@ where
 
 	state.record_codedeposit(retbuf.len())?;
 
-	handler.set_code(address, retbuf)?;
+	handler.set_code(address, retbuf, caller)?;
 
 	Ok(())
 }


### PR DESCRIPTION
### What does it do?

Adds a new `caller` parameter to `set_code` function. This change, allows to manage several behaviors inside each custom implementation of `set_code`, like applying a filter to control which addresses can deploy a contract via inner calls of type `CALL(CREATE)`.

To give more context, in Tanssi and our corresponding forks (of both Frontier and evm), we have implemented such use case. More specifically we have two filters implemented in Frontier:

- `CreateOrigin`: this filter acts when an account is trying to deploy a contract via CREATE method, which is the direct way of creating contracts. In this case, we don't need the caller to be present in `set_code()` as we control the CREATE deployments in `pallet-evm` directly.

- `CreateInnerOrigin`: this filter is applied when an account is trying to deploy a contract via a CALL method, that internally contains a CREATE. In this case, we need the caller to be present in `set_code()`, as this creation will take place inside the substack, and we can't control that behavior from `pallet-evm`.

Also, a good aspect of this change, is that it doesn't break any existing behavior nor compatibility inside the evm.

### Implementation PRs (Tanssi and forks)

**[Tanssi]** Contract deployment customization in frontier template: https://github.com/moondance-labs/tanssi/pull/571
**[Frontier fork]** Customize origin for contract deployment: https://github.com/moondance-labs/frontier/pull/1
**[evm fork]** Modify `set_code` to make it fallible: https://github.com/moondance-labs/evm/pull/1

