### PR TITLE
Check `exit_substate` result before `set_code`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm"
-version = "0.41.1"
+version = "0.41.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1017,10 +1017,10 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 							return (e.into(), None, Vec::new());
 						}
 						let exit_result = self.exit_substate(StackExitKind::Succeeded);
-						self.state.set_code(address, out);
 						if let Err(e) = exit_result {
 							return (e.into(), None, Vec::new());
 						}
+						self.state.set_code(address, out);
 						(ExitReason::Succeed(s), Some(address), Vec::new())
 					}
 					Err(e) => {


### PR DESCRIPTION
Always verify exit_result before updating the state (set_code).

Note: A patch for the v0.41.1 version.