### PR TITLE
Export evm_tracer::standard mod

### DIFF
--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -1,4 +1,4 @@
-mod standard;
+pub mod standard;
 
 use evm::interpreter::{machine::Machine, opcode::Opcode};
 


### PR DESCRIPTION
Was it meant to be public? I don't see how else it is useful...