### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ are welcomed.
   additional precompiles, different gasometers or other more exotic use cases.
 * **Portable** - support `no_std`, and can be used in different environments
   like in WebAssembly.
-* **Fast** - we of course try to be fast!
+* **Fast** - we of course try our best to be fast!
 * written in Rust, can be used as a binary, cargo crate or shared library.
 
 ## Dependencies


### PR DESCRIPTION
### Fix typo for smoother sentence structure

I found a small typo in the following sentence:

**"we of course try to be fast!"**

### Explanation of the fix:
The sentence would sound more natural if "try our best" is used instead of "try to." This revision makes the phrase grammatically smoother and clearer, improving the overall readability.

### Suggested correction:
**"we of course try our best to be fast!"**

This change enhances the flow of the sentence and aligns it with standard phrasing.
