### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ interpreter that can be easily customized.
 The Rust EVM project has a long history dating back to the initial
 implementation in 2017 (when it was called SputnikVM). It has gone through
 multiple rewrites over the years to accommodate for different requirements,
-when we successfully tested one integrating Geth to sync the mainnet.
+when we successfully tested it by integrating Geth to sync the mainnet.
 
 The current rewrite is used in production for the Frontier project (the
 Ethereum-compatibility layer for Polkadot). However, we have not yet fully


### PR DESCRIPTION
### Fix Typo in Documentation

This pull request addresses a small but important typo in the documentation for Rust EVM. The phrase:

**"when we successfully tested one integrating Geth to sync the mainnet."**

has been corrected to:

**"when we successfully tested it by integrating Geth to sync the mainnet."**

### Importance of the Fix:
This correction is important for clarity and accuracy. The original sentence was slightly confusing due to the use of "one" instead of "it" and the preposition "by" to describe the action of integrating Geth. The corrected version makes the intent clearer, ensuring that users understand the context of the integration and testing process more effectively.

Thank you for considering this improvement!
