### PR TITLE
Manage `primitive-types` dependency through `evm-core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 auto_impl = "1.0"
 ethereum = { git = "https://github.com/rust-ethereum/ethereum.git", rev = "3be0d8fd4c2ad1ba216b69ef65b9382612efc8ba", default-features = false }
 log = { version = "0.4", default-features = false }
-primitive-types = { version = "0.13", default-features = false, features = ["rlp"] }
 rlp = { version = "0.6", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 
@@ -39,7 +38,6 @@ default = ["std"]
 std = [
 	"ethereum/std",
 	"log/std",
-	"primitive-types/std",
 	"rlp/std",
 	"sha3/std",
 	"environmental/std",
@@ -53,14 +51,11 @@ std = [
 with-codec = [
 	"scale-codec",
 	"scale-info",
-	"primitive-types/codec",
-	"primitive-types/scale-info",
 	"ethereum/with-scale",
 	"evm-core/with-codec",
 ]
 with-serde = [
 	"serde",
-	"primitive-types/impl-serde",
 	"evm-core/with-serde",
 	"ethereum/with-serde",
 ]

--- a/benches/loop.rs
+++ b/benches/loop.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use evm::backend::{MemoryAccount, MemoryBackend, MemoryVicinity};
 use evm::executor::stack::{MemoryStackState, StackExecutor, StackSubstateMetadata};
+use evm::primitive_types::{H160, U256};
 use evm::Config;
-use primitive_types::{H160, U256};
 use std::{collections::BTreeMap, str::FromStr};
 
 fn run_loop_contract() {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 log = { version = "0.4", optional = true }
-primitive-types = { version = "0.13", default-features = false }
+primitive-types = { version = "0.13", default-features = false, features = ["rlp"] }
 scale-codec = { package = "parity-scale-codec", version = "3.2", default-features = false, features = ["derive", "full"], optional = true }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
@@ -29,7 +29,7 @@ std = [
 with-codec = [
 	"scale-codec",
 	"scale-info",
-	"primitive-types/impl-codec",
+	"primitive-types/scale-info",
 ]
 with-serde = [
 	"serde",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,8 @@ pub use crate::opcode::Opcode;
 pub use crate::stack::Stack;
 pub use crate::valids::Valids;
 
+pub use primitive_types;
+
 use crate::eval::{eval, Control};
 use alloc::rc::Rc;
 use alloc::vec::Vec;

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 [dependencies]
 environmental = { version = "1.1.2", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
-primitive-types = { version = "0.13", default-features = false }
 
 evm-core = { version = "0.42", path = "../core", default-features = false }
 evm-runtime = { version = "0.42", path = "../runtime", default-features = false }
@@ -20,7 +19,6 @@ evm-runtime = { version = "0.42", path = "../runtime", default-features = false 
 default = ["std"]
 std = [
 	"environmental/std",
-	"primitive-types/std",
 	"evm-core/std",
 	"evm-runtime/std",
 ]

--- a/gasometer/src/costs.rs
+++ b/gasometer/src/costs.rs
@@ -1,7 +1,7 @@
 use crate::consts::*;
 use crate::Config;
+use evm_core::primitive_types::{H256, U256};
 use evm_core::ExitError;
-use primitive_types::{H256, U256};
 
 pub fn call_extra_check(gas: U256, after_gas: u64, config: &Config) -> Result<(), ExitError> {
 	if config.err_on_call_with_more_gas && U256::from(after_gas) < gas {

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -39,9 +39,9 @@ mod utils;
 
 use alloc::vec::Vec;
 use core::cmp::max;
+use evm_core::primitive_types::{H160, H256, U256};
 use evm_core::{ExitError, Opcode, Stack};
 use evm_runtime::{Config, Handler};
-use primitive_types::{H160, H256, U256};
 
 macro_rules! try_or_fail {
 	( $inner:expr, $e:expr ) => {

--- a/gasometer/src/utils.rs
+++ b/gasometer/src/utils.rs
@@ -1,4 +1,4 @@
-use primitive_types::U256;
+use evm_core::primitive_types::U256;
 
 pub fn log2floor(value: U256) -> u64 {
 	assert!(value != U256::zero());

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 [dependencies]
 auto_impl = "1.0"
 environmental = { version = "1.1.2", default-features = false, optional = true }
-primitive-types = { version = "0.13", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 
 evm-core = { version = "0.42", path = "../core", default-features = false }
@@ -20,7 +19,6 @@ evm-core = { version = "0.42", path = "../core", default-features = false }
 default = ["std"]
 std = [
 	"environmental/std",
-	"primitive-types/std",
 	"sha3/std",
 	"evm-core/std",
 ]

--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -1,4 +1,4 @@
-use primitive_types::{H160, H256, U256};
+use evm_core::primitive_types::{H160, H256, U256};
 
 /// Create scheme.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]

--- a/runtime/src/eval/mod.rs
+++ b/runtime/src/eval/mod.rs
@@ -5,7 +5,7 @@ mod system;
 use crate::{CallScheme, ExitReason, Handler, Opcode, Runtime};
 use alloc::vec::Vec;
 use core::cmp::min;
-use primitive_types::{H160, H256, U256};
+use evm_core::primitive_types::{H160, H256, U256};
 
 pub enum Control<H: Handler> {
 	Continue,

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -4,7 +4,7 @@ use crate::{
 	Runtime, Transfer,
 };
 use alloc::vec::Vec;
-use primitive_types::{H256, U256};
+use evm_core::primitive_types::{H256, U256};
 use sha3::{Digest, Keccak256};
 
 pub fn sha3<H: Handler>(runtime: &mut Runtime) -> Control<H> {

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -1,6 +1,6 @@
 use crate::{Capture, Context, CreateScheme, ExitError, ExitReason, Machine, Opcode, Stack};
 use alloc::vec::Vec;
-use primitive_types::{H160, H256, U256};
+use evm_core::primitive_types::{H160, H256, U256};
 
 /// Transfer from source to target, with given value.
 #[derive(Clone, Debug)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::interrupt::{Resolve, ResolveCall, ResolveCreate};
 
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use primitive_types::{H160, U256};
+use evm_core::primitive_types::{H160, U256};
 
 macro_rules! step {
 	( $self:expr, $handler:expr, $return:tt $($err:path)?; $($ok:path)? ) => ({

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -1,7 +1,7 @@
 //! Allows to listen to runtime events.
 
 use crate::{Capture, Context, ExitReason, Memory, Opcode, Stack, Trap};
-use primitive_types::{H160, H256};
+use evm_core::primitive_types::{H160, H256};
 
 environmental::environmental!(listener: dyn EventListener + 'static);
 

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -1,7 +1,7 @@
 use super::{Apply, ApplyBackend, Backend, Basic, Log};
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use primitive_types::{H160, H256, U256};
+use evm_core::primitive_types::{H160, H256, U256};
 
 /// Vicinity value of a memory backend.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -6,7 +6,7 @@ mod memory;
 
 pub use self::memory::{MemoryAccount, MemoryBackend, MemoryVicinity};
 use alloc::vec::Vec;
-use primitive_types::{H160, H256, U256};
+use evm_core::primitive_types::{H160, H256, U256};
 /// Basic account information.
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 #[cfg_attr(

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -11,9 +11,9 @@ use crate::{
 };
 use alloc::{collections::BTreeSet, rc::Rc, vec::Vec};
 use core::{cmp::min, convert::Infallible};
+use evm_core::primitive_types::{H160, H256, U256};
 use evm_core::ExitFatal;
 use evm_runtime::Resolve;
-use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
 
 macro_rules! emit_exit {

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -7,7 +7,7 @@ use alloc::{
 	vec::Vec,
 };
 use core::mem;
-use primitive_types::{H160, H256, U256};
+use evm_core::primitive_types::{H160, H256, U256};
 
 #[derive(Clone, Debug)]
 pub struct MemoryStackAccount {

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -1,6 +1,6 @@
 use crate::{Context, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed, Transfer};
 use alloc::{collections::BTreeMap, vec::Vec};
-use primitive_types::{H160, H256};
+use evm_core::primitive_types::{H160, H256};
 
 /// A precompile result.
 pub type PrecompileResult = Result<PrecompileOutput, PrecompileFailure>;

--- a/src/executor/stack/tagged_runtime.rs
+++ b/src/executor/stack/tagged_runtime.rs
@@ -3,7 +3,7 @@
 
 use crate::maybe_borrowed::MaybeBorrowed;
 use crate::Runtime;
-use primitive_types::H160;
+use evm_core::primitive_types::H160;
 
 pub struct TaggedRuntime<'borrow> {
 	pub kind: RuntimeKind,

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,8 +1,8 @@
 //! Allows to listen to runtime events.
 
 use crate::Context;
+use evm_core::primitive_types::{H160, H256, U256};
 use evm_runtime::{CreateScheme, ExitReason, Transfer};
-use primitive_types::{H160, H256, U256};
 
 environmental::environmental!(listener: dyn EventListener + 'static);
 


### PR DESCRIPTION
This PR refactors the dependency management of primitive-types across crates that depend on `evm-core`. Previously, each crate managed its own version of primitive-types, which introduced the risk of version mismatches and inconsistency. With this change, `evm-core` now re-exports `primitive-types`, and all dependent crates utilize this re-export.