### PR TITLE
Expose origin and the addresses of contracts being constructed in precompile handle

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1582,6 +1582,11 @@ impl<'config, S: StackState<'config>, P: PrecompileSet> PrecompileHandle
 		self.context
 	}
 
+	/// Retreive the address of the EOA that originated the transaction.
+	fn origin(&self) -> H160 {
+		self.executor.state.origin()
+	}
+
 	/// Is the precompile call is done statically.
 	fn is_static(&self) -> bool {
 		self.is_static
@@ -1590,5 +1595,10 @@ impl<'config, S: StackState<'config>, P: PrecompileSet> PrecompileHandle
 	/// Retreive the gas limit of this call.
 	fn gas_limit(&self) -> Option<u64> {
 		self.gas_limit
+	}
+
+	/// Check if a given address is a contract being constructed
+	fn is_contract_being_constructed(&self, address: H160) -> bool {
+		self.executor.state.created(address)
 	}
 }

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -76,11 +76,17 @@ pub trait PrecompileHandle {
 	/// Retreive the context in which the precompile is executed.
 	fn context(&self) -> &Context;
 
+	/// Retreive the address of the EOA that originated the transaction.
+	fn origin(&self) -> H160;
+
 	/// Is the precompile call is done statically.
 	fn is_static(&self) -> bool;
 
 	/// Retreive the gas limit of this call.
 	fn gas_limit(&self) -> Option<u64>;
+
+	/// Check if a given address is a contract being constructed
+	fn is_contract_being_constructed(&self, address: H160) -> bool;
 }
 
 /// A set of precompiles.


### PR DESCRIPTION
Exposes the transaction origin in precompile handle, this can be used to identify if an address is an Externally Owner Account (EOA). (`tx.origin == msg.sender`)

This is necessary to distinguish addresses from contracts under-construction and real EOA's, since contracts under-construction only have code after the `init_code` is executed.

Exposing the `origin` to precompiles will be required for supporting https://eips.ethereum.org/EIPS/eip-7702, since it adds the possibility for EOA to have code.

