### PR TITLE
Improve ergonomics of EIP-7702 authorization list processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 auto_impl = "1.0"
-ethereum = { version = "0.16.0", default-features = false }
+ethereum = { git = "https://github.com/manuelmauro/ethereum.git", rev = "844132a944fa3e9896ba6ed55e8d466c26bd793f", default-features = false }
 log = { version = "0.4", default-features = false }
 primitive-types = { version = "0.13", default-features = false, features = ["rlp"] }
 rlp = { version = "0.6", default-features = false }


### PR DESCRIPTION
## Description

Using a `Option<H160>` for the authorization address allows to send a `None` value when the signature (`r`, `s`, `y_parity`) is invalid and the authorization needs to be skipped as described in [step 3 of EIP-7702](https://eips.ethereum.org/EIPS/eip-7702#specification).

