### PR TITLE
Better EIP-7702 ergonomics

### DIFF
--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -335,7 +335,7 @@ impl<'config> Gasometer<'config> {
 pub fn call_transaction_cost(
 	data: &[u8],
 	access_list: &[(H160, Vec<H256>)],
-	authorization_list: &[(U256, H160, U256, H160)],
+	authorization_list: &[(U256, H160, U256, Option<H160>)],
 ) -> TransactionCost {
 	let zero_data_len = data.iter().filter(|v| **v == 0).count();
 	let non_zero_data_len = data.len() - zero_data_len;
@@ -358,7 +358,7 @@ pub fn call_transaction_cost(
 pub fn create_transaction_cost(
 	data: &[u8],
 	access_list: &[(H160, Vec<H256>)],
-	authorization_list: &[(U256, H160, U256, H160)],
+	authorization_list: &[(U256, H160, U256, Option<H160>)],
 ) -> TransactionCost {
 	let zero_data_len = data.iter().filter(|v| **v == 0).count();
 	let non_zero_data_len = data.len() - zero_data_len;

--- a/tests/eip7702.rs
+++ b/tests/eip7702.rs
@@ -16,8 +16,8 @@ fn create_authorization(
 	delegation_address: H160,
 	nonce: U256,
 	authorizing_address: H160,
-) -> (U256, H160, U256, H160) {
-	(chain_id, delegation_address, nonce, authorizing_address)
+) -> (U256, H160, U256, Option<H160>) {
+	(chain_id, delegation_address, nonce, Some(authorizing_address))
 }
 
 /// Create a test vicinity for EIP-7702 tests


### PR DESCRIPTION
## Description

Using a `Option<H160>` for the authorization address allows to send a `None` value when the signature (`r`, `s`, `y_parity`) is invalid and the authorization needs to be skipped as described in [step 3 of EIP-7702](https://eips.ethereum.org/EIPS/eip-7702#specification).
