### PR TITLE
feat: add Log tracing event

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1411,6 +1411,11 @@ impl<'config, S: StackState<'config>, P: PrecompileSet> Handler
 	}
 
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) -> Result<(), ExitError> {
+		event!(Log {
+			address,
+			topics,
+			data
+		});
 		self.state.log(address, topics, data);
 		Ok(())
 	}

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -67,6 +67,11 @@ pub enum Event<'a> {
 		is_static: bool,
 		context: &'a Context,
 	},
+	Log {
+		address: H160,
+		topics: &'a [H256],
+		data: &'a [u8],
+	},
 }
 
 // Expose `listener::with` to the crate only.


### PR DESCRIPTION
The Log event is necessary for supporting the `withLog` argument in the [callTracer config](https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers).