### PR TITLE
fix: The nonce must be incremented before any gas record

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -664,6 +664,12 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 			gas_limit,
 		});
 
+		// The nonce must be incremented before any gas record,
+		// otherwise we might OOG without incrementing the nonce!
+		if let Err(e) = self.state.inc_nonce(caller) {
+			return (e.into(), Vec::new());
+		}
+
 		let transaction_cost =
 			gasometer::call_transaction_cost(&data, &access_list, &authorization_list);
 		let gasometer = &mut self.state.metadata_mut().gasometer;
@@ -695,9 +701,6 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		}
 
 		if let Err(e) = self.record_external_operation(crate::ExternalOperation::AccountBasicRead) {
-			return (e.into(), Vec::new());
-		}
-		if let Err(e) = self.state.inc_nonce(caller) {
 			return (e.into(), Vec::new());
 		}
 


### PR DESCRIPTION
Fixes a condition where could fail while recording gas without incrementing the nonce.