### PR TITLE
chore: fix typos in comments and error messages

### DIFF
--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -32,7 +32,7 @@ pub struct RuntimeConfig {
 	pub eip161_empty_check: bool,
 	/// EIP-7610: check whether storage is empty in create collision logic.
 	pub eip7610_create_check_storage: bool,
-	/// EIP-6780: selfdestruct deletet contract only if called in the same tx as creation
+	/// EIP-6780: selfdestruct deletes contract only if called in the same tx as creation
 	pub eip6780_suicide_only_in_same_tx: bool,
 	/// EIP-3651
 	pub eip3651_warm_coinbase_address: bool,

--- a/precompile/src/simple.rs
+++ b/precompile/src/simple.rs
@@ -49,7 +49,7 @@ impl<G: GasMutState> PurePrecompile<G> for ECRecover {
 			}
 
 			let recid = RecoveryId::from_byte(raw_recid)
-				.ok_or(ExitException::Other("invalid recoverty id".into()))?; // v
+				.ok_or(ExitException::Other("invalid recovery id".into()))?; // v
 
 			let pubkey = VerifyingKey::recover_from_prehash(&msg[..], &sig, recid)
 				.map_err(|_| ExitException::Other("recover key failed".into()))?;


### PR DESCRIPTION
- runtime.rs: corrected "deletet" → "deletes" in EIP-6780 comment.
- simple.rs: corrected "recoverty id" → "recovery id" in ECRecover error message.